### PR TITLE
refactor: 필요없는 JPA 어노테이션 제거 / lenth 부여 / nullable false 추가

### DIFF
--- a/src/main/java/com/hack/stock2u/models/Attach.java
+++ b/src/main/java/com/hack/stock2u/models/Attach.java
@@ -2,9 +2,12 @@ package com.hack.stock2u.models;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,16 +17,18 @@ import lombok.NoArgsConstructor;
 @Entity(name = "attachments")
 public class Attach {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column
   private String name;
 
-  @Column
+  @Column(length = 15)
   private String ext;
 
-  @Column(name = "upload_path")
+  @Column(name = "upload_path", length = 500)
   private String uploadPath;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
 }

--- a/src/main/java/com/hack/stock2u/models/Buyer.java
+++ b/src/main/java/com/hack/stock2u/models/Buyer.java
@@ -19,7 +19,6 @@ import org.hibernate.annotations.Comment;
 
 public class Buyer {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 

--- a/src/main/java/com/hack/stock2u/models/Product.java
+++ b/src/main/java/com/hack/stock2u/models/Product.java
@@ -17,8 +17,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,24 +27,21 @@ import org.hibernate.annotations.Comment;
 @Entity(name = "products")
 public class Product {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @Comment("판매글 제목")
-  @Column
   private String title;
 
   @Comment("재고 이름")
-  @Column
   private String name;
 
   @Comment("재고 분류")
-  @Enumerated(EnumType.ORDINAL)
+  @Enumerated(EnumType.STRING)
   private ProductType type;
 
   @Comment("재고 설명")
-  @Column
+  @Column(length = 1000)
   private String description;
 
   @Comment("예약 한 건만 받기")
@@ -59,18 +54,15 @@ public class Product {
 
   @Comment("게시 마감 기한")
   @Column(name = "expired_at")
-  @Temporal(TemporalType.TIMESTAMP)
   private Date expiredAt;
 
   @Enumerated(EnumType.ORDINAL)
   private ReservationStatus status;
 
   @Comment("위도")
-  @Column
   private Double latitude;
 
   @Comment("경도")
-  @Column
   private Double longitude;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/hack/stock2u/models/ProductImage.java
+++ b/src/main/java/com/hack/stock2u/models/ProductImage.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 @Entity(name = "product_images")
 public class ProductImage {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 

--- a/src/main/java/com/hack/stock2u/models/ProductReservation.java
+++ b/src/main/java/com/hack/stock2u/models/ProductReservation.java
@@ -1,0 +1,32 @@
+package com.hack.stock2u.models;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "product_reservations")
+public class ProductReservation {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Comment("재고 상품 id")
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id")
+  private Product product;
+
+  @Comment("예약 현황 id")
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "reservation_id")
+  private Reservation reservation;
+}

--- a/src/main/java/com/hack/stock2u/models/Report.java
+++ b/src/main/java/com/hack/stock2u/models/Report.java
@@ -18,12 +18,10 @@ import org.hibernate.annotations.Comment;
 @Entity(name = "reports")
 public class Report {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @Comment("신고 사유")
-  @Column
   private String reason;
 
   @Comment("신고자 id")

--- a/src/main/java/com/hack/stock2u/models/Reservation.java
+++ b/src/main/java/com/hack/stock2u/models/Reservation.java
@@ -23,7 +23,6 @@ import org.hibernate.annotations.Comment;
 @Entity(name = "reservations")
 public class Reservation {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 

--- a/src/main/java/com/hack/stock2u/models/Reservation.java
+++ b/src/main/java/com/hack/stock2u/models/Reservation.java
@@ -30,6 +30,8 @@ public class Reservation {
   @Column(name = "chat_id")
   private String chatId;
 
+
+
   @Comment("판매자(사업자) id")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "seller_id")

--- a/src/main/java/com/hack/stock2u/models/SellerDetails.java
+++ b/src/main/java/com/hack/stock2u/models/SellerDetails.java
@@ -15,30 +15,28 @@ import org.hibernate.annotations.Comment;
 @Entity(name = "seller_details")
 public class SellerDetails {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @Comment("사업자등록번호")
-  @Column(name = "license_number")
+  @Column(name = "license_number", length = 40)
   private String licenseNumber;
 
   @Comment("업종")
-  @Column
+  @Column(length = 100)
   private String industry;
 
   @Comment("사업지명")
-  @Column(name = "industry_name")
+  @Column(name = "industry_name", length = 50)
   private String industryName;
 
   @Comment("소재지")
-  @Column
   private String location;
 
-  @Column(name = "bank_name")
+  @Column(name = "bank_name", length = 30)
   private String bankName;
 
   @Comment("계좌번호")
-  @Column
+  @Column(length = 50)
   private String account;
 }

--- a/src/main/java/com/hack/stock2u/models/Subscription.java
+++ b/src/main/java/com/hack/stock2u/models/Subscription.java
@@ -1,6 +1,5 @@
 package com.hack.stock2u.models;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -18,7 +17,6 @@ import org.hibernate.annotations.Comment;
 @Entity(name = "subscriptions")
 public class Subscription {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 

--- a/src/main/java/com/hack/stock2u/models/User.java
+++ b/src/main/java/com/hack/stock2u/models/User.java
@@ -62,7 +62,7 @@ public class User {
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "buyer")
   private List<Buyer> buyers;
 
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "user_id")
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
   private List<Attach> attaches;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")

--- a/src/main/java/com/hack/stock2u/models/User.java
+++ b/src/main/java/com/hack/stock2u/models/User.java
@@ -34,6 +34,8 @@ public class User {
   @Column(length = 20, nullable = false)
   private String phone;
 
+  private String password;
+
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private UserRole role;

--- a/src/main/java/com/hack/stock2u/models/User.java
+++ b/src/main/java/com/hack/stock2u/models/User.java
@@ -16,8 +16,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,17 +25,17 @@ import lombok.NoArgsConstructor;
 @Entity(name = "users")
 public class User {
   @Id
-  @Column
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column
+  @Column(length = 30, nullable = false)
   private String name;
 
-  @Column
+  @Column(length = 20, nullable = false)
   private String phone;
 
-  @Enumerated(EnumType.ORDINAL)
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
   private UserRole role;
 
   @Column(name = "avatar_id")
@@ -46,11 +44,10 @@ public class User {
   @Column(name = "withdraw_reason")
   private String withdrawReason;
 
-  @Column(name = "report_count")
+  @Column(name = "report_count", nullable = false)
   private short reportCount;
 
   @Column(name = "disabled_at")
-  @Temporal(TemporalType.TIMESTAMP)
   private Date disabledAt;
 
   @Embedded
@@ -63,7 +60,7 @@ public class User {
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "buyer")
   private List<Buyer> buyers;
 
-  @OneToMany(fetch = FetchType.LAZY)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "user_id")
   private List<Attach> attaches;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")

--- a/src/main/java/com/hack/stock2u/models/embed/BasicDateColumn.java
+++ b/src/main/java/com/hack/stock2u/models/embed/BasicDateColumn.java
@@ -3,8 +3,6 @@ package com.hack.stock2u.models.embed;
 import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import lombok.Getter;
 
 @Getter
@@ -12,10 +10,8 @@ import lombok.Getter;
 public class BasicDateColumn {
 
   @Column(name = "created_at")
-  @Temporal(TemporalType.TIMESTAMP)
   private Date createdAt;
 
   @Column(name = "removed_at")
-  @Temporal(TemporalType.TIMESTAMP)
   private Date removedAt;
 }


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
* JPA 어노테이션 중 기본적으로 적용되는 값은 제거하였습니다.
* null 이 되면 안되는 몇몇 컬럼에 nullable 요소 false 를 추가하였습니다.
* 길이가 고정되어있는 필드에 대해 length 값을 부여하였습니다. (기본 길이 제한 255 )