### PR TITLE
feat: 각 인증 벤더사를 의미하는 AuthVendor 객체와 컨버터 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
@@ -38,6 +39,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation "org.springdoc:springdoc-openapi-ui:1.6.12"
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hack/stock2u/authentication/service/AuthVendorEnumConverter.java
+++ b/src/main/java/com/hack/stock2u/authentication/service/AuthVendorEnumConverter.java
@@ -1,0 +1,13 @@
+package com.hack.stock2u.authentication.service;
+
+import com.hack.stock2u.constant.AuthVendor;
+import org.springframework.core.convert.converter.Converter;
+
+public class AuthVendorEnumConverter implements Converter<String, AuthVendor> {
+
+  @Override
+  public AuthVendor convert(String source) {
+    return AuthVendor.findByName(source);
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/constant/AuthVendor.java
+++ b/src/main/java/com/hack/stock2u/constant/AuthVendor.java
@@ -1,0 +1,32 @@
+package com.hack.stock2u.constant;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum AuthVendor {
+  GOOGLE("google"),
+  KAKAO("kakao"),
+  NAVER("naver");
+
+  private final String name;
+
+  AuthVendor(String name) {
+    this.name = name;
+  }
+
+  /**
+   * @param name kakao, naver, google 각 로그인 벤더사 이름
+   * @return AuthVendor
+   */
+  public static AuthVendor findByName(String name) {
+    return Arrays.stream(AuthVendor.values())
+        .filter(vendor -> {
+          String vendorName = vendor.getName();
+          return vendorName.equals(name);
+        })
+        .findAny()
+        .orElseThrow(IllegalArgumentException::new);
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/global/config/WebConfig.java
+++ b/src/main/java/com/hack/stock2u/global/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.hack.stock2u.global.config;
+
+import com.hack.stock2u.authentication.service.AuthVendorEnumConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new AuthVendorEnumConverter());
+  }
+
+}


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
각 인증 벤더사(Google, naver, kakao) 를 의미하는 객체와 클라이언트 요청에서
벤더 스트링을 enum 객체와 매핑하기 위한 코드를 작성하였습니다. 

