### PR TITLE
feat: 회원 가입 인증코드 발송 및 검증 API 작성

### DIFF
--- a/src/main/java/com/hack/stock2u/authentication/AuthException.java
+++ b/src/main/java/com/hack/stock2u/authentication/AuthException.java
@@ -1,0 +1,34 @@
+package com.hack.stock2u.authentication;
+
+import com.hack.stock2u.global.exception.BasicErrorCase;
+import com.hack.stock2u.global.exception.BasicErrorResponse;
+import com.hack.stock2u.global.exception.BasicException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthException implements BasicErrorCase {
+  EXPIRED_AUTH_CODE(HttpStatus.UNAUTHORIZED, "EXPIRED_AUTH_CODE", "인증코드 유효기간이 만료되었거나 존재하지 않습니다."),
+  MISMATCH_AUTH_CODE(HttpStatus.BAD_REQUEST, "MISMATCH_AUTH_CODE", "인증코드가 일치하지 않습니다"),
+  ALREADY_PASS_AUTH_CODE(HttpStatus.BAD_REQUEST, "ALREADY_PASS", "이미 검증 완료된 사용자입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String errorCode;
+  private final String message;
+
+  AuthException(HttpStatus httpStatus, String errorCode, String message) {
+    this.httpStatus = httpStatus;
+    this.errorCode = errorCode;
+    this.message = message;
+  }
+
+  @Override
+  public BasicException create() {
+    BasicErrorResponse response = BasicErrorResponse.builder()
+        .httpStatus(httpStatus)
+        .errorCode(errorCode)
+        .message(message)
+        .build();
+    return new BasicException(response);
+  }
+}

--- a/src/main/java/com/hack/stock2u/authentication/api/AuthApi.java
+++ b/src/main/java/com/hack/stock2u/authentication/api/AuthApi.java
@@ -54,7 +54,8 @@ public class AuthApi {
       @Parameter(
           name = "phone",
           description = "대상자의 핸드폰 번호",
-          required = true
+          required = true,
+          example = "01012341234"
       )
       @RequestParam("phone") String phone
   ) {

--- a/src/main/java/com/hack/stock2u/authentication/api/AuthApi.java
+++ b/src/main/java/com/hack/stock2u/authentication/api/AuthApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,6 +46,35 @@ public class AuthApi {
     String token = tokenRequest.token();
     LoginResponse login = authService.login(token);
     return ResponseEntity.ok().body(login);
+  }
+
+  @Operation(summary = "회원가입 인증코드 발송 API", description = "사용자의 스마트폰으로 SMS 인증코드를 발송합니다.")
+  @GetMapping("/code")
+  public ResponseEntity<Void> sendAuthCodeApi(
+      @Parameter(
+          name = "phone",
+          description = "대상자의 핸드폰 번호",
+          required = true
+      )
+      @RequestParam("phone") String phone
+  ) {
+    authService.sendCode(phone);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+  @Operation(
+      summary = "회원가입 인증코드 검증 API",
+      description = "발송된 회원 인증코드를 검증합니다. 해당 API 에서 검증 이후 회원가입이 가능합니다."
+  )
+  @PostMapping("/code/verify")
+  public ResponseEntity<Void> verifyAuthCodeApi(
+      @RequestBody AuthRequestDto.AuthCode authCodeRequest
+  ) {
+    String authCode = authCodeRequest.authCode();
+    String phone = authCodeRequest.phone();
+
+    authService.verifyCode(phone, authCode);
+    return ResponseEntity.status(HttpStatus.OK).build();
   }
 
 }

--- a/src/main/java/com/hack/stock2u/authentication/dto/AuthRequestDto.java
+++ b/src/main/java/com/hack/stock2u/authentication/dto/AuthRequestDto.java
@@ -7,4 +7,11 @@ public class AuthRequestDto {
 
   public record Token(@NotNull @NotBlank String token) {}
 
+  public record AuthCode(
+      @NotNull @NotBlank
+      String authCode,
+      @NotNull @NotBlank
+      String phone
+  ) {}
+
 }

--- a/src/main/java/com/hack/stock2u/authentication/service/AuthCodeProvider.java
+++ b/src/main/java/com/hack/stock2u/authentication/service/AuthCodeProvider.java
@@ -1,0 +1,54 @@
+package com.hack.stock2u.authentication.service;
+
+import com.hack.stock2u.global.factory.SmsFactory;
+import com.hack.stock2u.utils.Convertor;
+import com.hack.stock2u.utils.OneTimeCodeGenerator;
+import java.text.MessageFormat;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpServerErrorException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthCodeProvider {
+  private final RedisTemplate<String, Date> template;
+  private final String keyPrefix = "auth-verification-code";
+
+  public void save(String phone, int minutes) {
+    ValueOperations<String, Date> ops = template.opsForValue();
+    String newCode = OneTimeCodeGenerator.createDigit(6);
+
+    String key = createKey(phone);
+    ops.append(key, newCode);
+
+    String message = MessageFormat.format(SmsMessage.SEND_CODE.getMessage(), newCode);
+    String korPhone = new Convertor().phone(phone);
+    String error =
+        SmsFactory.getSimpleMessageCreator(korPhone, message).create().getErrorMessage();
+
+    if (error != null) {
+      log.error("twilio error: {}", error);
+      throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    template.expire(key, minutes, TimeUnit.MINUTES);
+  }
+
+  public void verifyCode(String phone, String code) {
+    ValueOperations<String, Date> ops = template.opsForValue();
+    Date target = ops.get(createKey(phone));
+    log.warn("target: {}", target);
+  }
+
+  private String createKey(String phone) {
+    return keyPrefix + ":" + phone;
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/authentication/service/AuthService.java
+++ b/src/main/java/com/hack/stock2u/authentication/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.hack.stock2u.authentication.service;
 
+import com.hack.stock2u.authentication.dto.AuthRequestDto;
 import com.hack.stock2u.authentication.dto.LoginResponse;
 import com.hack.stock2u.authentication.dto.TokenSet;
 import com.hack.stock2u.authentication.dto.UrlJson;
@@ -28,6 +29,7 @@ public class AuthService {
   private final KakaoClient kakaoClient;
   private final JpaUserRepository userRepository;
   private final AuthenticationManager authManager;
+  private final AuthCodeProvider authCodeProvider;
 
   /**
    * AuthVendor 에 따른 각 Vendor 로그인을 수행하는 URL 을 반환합니다.
@@ -55,7 +57,17 @@ public class AuthService {
     return new LoginResponse(true, email);
   }
 
-  public void signup() {}
+  public void signup() {
+
+  }
+
+  public void sendCode(String phone) {
+    authCodeProvider.save(phone, 10);
+  }
+
+  public void verifyCode(String phone, String authCode) {
+    authCodeProvider.verifyCode(phone, authCode);
+  }
 
   private void processLogin(User user) {
     UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/hack/stock2u/authentication/service/SmsMessage.java
+++ b/src/main/java/com/hack/stock2u/authentication/service/SmsMessage.java
@@ -1,0 +1,20 @@
+package com.hack.stock2u.authentication.service;
+
+import lombok.Getter;
+
+@Getter
+public enum SmsMessage {
+  SEND_CODE("""
+  [Stock2U]
+  회원가입 사용자 인증코드를 발송하였습니다.
+  인증코드: {0}
+  5분 이후 해당 코드는 만료되니 주의바랍니다.
+  """);
+
+  private final String message;
+
+  SmsMessage(String message) {
+    this.message = message;
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/global/config/RedisConfig.java
+++ b/src/main/java/com/hack/stock2u/global/config/RedisConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Slf4j
 @Configuration
@@ -20,6 +22,14 @@ public class RedisConfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
     return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public RedisTemplate<?, ?> redisTemplate() {
+    RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    return redisTemplate;
   }
 
 }

--- a/src/main/java/com/hack/stock2u/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hack/stock2u/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.support.MethodArgumentTypeMismatchException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -17,7 +18,8 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(res.httpStatus()).body(res);
   }
 
-  @ExceptionHandler({MethodArgumentTypeMismatchException.class, IllegalArgumentException.class})
+  @ExceptionHandler({MethodArgumentTypeMismatchException.class, IllegalArgumentException.class,
+      MissingServletRequestParameterException.class})
   protected ResponseEntity<BasicErrorResponse> handleIllegalArgsException(Exception ex) {
     String message = ex.getLocalizedMessage();
     String errorMessage = getSimpleMessage(message, IllegalArgumentException.class.getName());
@@ -40,5 +42,4 @@ public class GlobalExceptionHandler {
     }
     return fullText.substring(startIdx + exName.length() + 2);
   }
-
 }

--- a/src/main/java/com/hack/stock2u/global/factory/SmsFactory.java
+++ b/src/main/java/com/hack/stock2u/global/factory/SmsFactory.java
@@ -22,7 +22,6 @@ public class SmsFactory {
       @Value("${app.twilio.token}") String token,
       @Value("${app.twilio.phone}") String phone
   ) {
-    log.warn("sid: {}, token: {}, phone: {}", sid, token, phone);
     SmsFactory.sid = sid;
     SmsFactory.token = token;
     SmsFactory.phone = phone;

--- a/src/main/java/com/hack/stock2u/utils/Convertor.java
+++ b/src/main/java/com/hack/stock2u/utils/Convertor.java
@@ -1,0 +1,13 @@
+package com.hack.stock2u.utils;
+
+public class Convertor {
+
+  /**
+   * 한국에서 사용하는 폰번호 형식으로 변환된 데이터를 반환합니다. (+82...)
+   */
+  public String phone(String number) {
+    String sub = number.substring(1);
+    return "+82" + sub;
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/utils/OneTimeCodeGenerator.java
+++ b/src/main/java/com/hack/stock2u/utils/OneTimeCodeGenerator.java
@@ -1,0 +1,22 @@
+package com.hack.stock2u.utils;
+
+import java.util.Random;
+
+public class OneTimeCodeGenerator {
+
+  /**
+   * 지정된 자리의 숫자로 구성된 랜덤코드를 생성합니다.
+   */
+  public static String createDigit(int len) {
+    Random r = new Random();
+    StringBuilder sb = new StringBuilder(len);
+
+    for (int i = 0; i < len; i++) {
+      int n = r.nextInt(10);
+      sb.append(n);
+    }
+
+    return sb.toString();
+  }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -78,12 +78,14 @@ spring:
     database: mysql
   data:
     mongodb:
-      uri: ${HOME_MONGO_URI}
-      database: "stock2u"
+#      uri: ${HOME_MONGO_URI}
       host: ${HOME_MONGO_HOST}
       port: 27017
+      database: local
       password: ${HOME_MONGO_PASSWORD}
       username: ${HOME_MONGO_USERNAME}
+      authentication-database: admin
+
   redis:
     host: ${HOME_REDIS_HOST}
     port: 6379

--- a/src/test/java/com/hack/stock2u/utils/ConvertorTest.java
+++ b/src/test/java/com/hack/stock2u/utils/ConvertorTest.java
@@ -1,0 +1,28 @@
+package com.hack.stock2u.utils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ConvertorTest {
+  final Convertor convertor = new Convertor();
+  Logger logger = LoggerFactory.getLogger("OneTimeCodeGeneratorTest");
+
+  @Test
+  @DisplayName("휴대폰 번호를 성공적으로 한국번호로 변환한다.")
+  void convertKorPhone() {
+    // given
+    String p = "01026554276";
+
+    // when
+    String phone = convertor.phone(p);
+
+    // then
+    logger.warn("phone: {}", phone);
+    assertThat(phone).startsWith("+82");
+  }
+
+}

--- a/src/test/java/com/hack/stock2u/utils/OneTimeCodeGeneratorTest.java
+++ b/src/test/java/com/hack/stock2u/utils/OneTimeCodeGeneratorTest.java
@@ -1,0 +1,26 @@
+package com.hack.stock2u.utils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OneTimeCodeGeneratorTest {
+  Logger logger = LoggerFactory.getLogger("OneTimeCodeGeneratorTest");
+
+  @Test
+  @DisplayName("6자리 숫자 코드를 정상적으로 생성한다.")
+  void create6DigitCode() {
+    String code = OneTimeCodeGenerator.createDigit(6);
+    logger.info("code: {}", code);
+    char[] arr = code.toCharArray();
+
+    for (var c : arr) {
+      int num = Character.getNumericValue(c);
+      assertThat(Integer.class.isInstance(num)).isTrue();
+    }
+  }
+
+}


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

Implements [issue SU-28](https://geezers-io.atlassian.net/browse/SU-28)
Implements [issue SU-29](https://geezers-io.atlassian.net/browse/SU-29)

## Important
.env 가 갱신되었습니다.
백엔드 개발자분들 새로 값 요청하여 .env 내용 수정하시길 바랍니다!

## What & Why
회원가입이나 유저 정보 수정을 위한 일회성 인증코드(유효 기간 5분) 를 회원에게 SMS 발송 및
발송된 인증코드 검증을 수행하는 API를 작성하였습니다.

![image](https://github.com/geezers-io/Stock2U-api/assets/50310464/58ce2175-97e7-4233-b098-b38a877b8148)


![image](https://github.com/geezers-io/Stock2U-api/assets/50310464/e8272c04-33b7-43b4-b548-77d7acfb42fe)


## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
