### PR TITLE
feat: HTTP 커스텀 로깅 / API 별 권한 체크 기능

### DIFF
--- a/src/main/java/com/hack/stock2u/authentication/api/AuthApi.java
+++ b/src/main/java/com/hack/stock2u/authentication/api/AuthApi.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -56,10 +57,14 @@ public class AuthApi {
   @Operation(summary = "로그인 API", description = "로그인을 수행합니다.")
   @PostMapping("/signin")
   public ResponseEntity<SignInResponse> signInApi(
-      @RequestBody @Valid AuthRequestDto.SignInRequest signInRequest
+      @RequestBody @Valid AuthRequestDto.SignInRequest signInRequest,
+      HttpSession session
   ) {
     String authCode = signInRequest.authCode();
     SignInResponse signIn = authService.signIn(authCode);
+    session.setAttribute("vendor", signIn.user().vendor().name());
+    session.setAttribute("userId", signIn.user().id());
+    session.setAttribute("role", signIn.user().role().name());
     return ResponseEntity.ok().body(signIn);
   }
 

--- a/src/main/java/com/hack/stock2u/authentication/service/AuthManager.java
+++ b/src/main/java/com/hack/stock2u/authentication/service/AuthManager.java
@@ -32,7 +32,6 @@ public class AuthManager implements AuthenticationManager {
     SessionUser user = SessionUser.user(userDetails.getUser());
 
     String key = sessionManager.getKey(phone, id);
-    log.error("redis session key: {}", key);
     ops.set(key, user);
     redisTemplate.expire(key, 1, TimeUnit.HOURS);
 

--- a/src/main/java/com/hack/stock2u/global/config/WebConfig.java
+++ b/src/main/java/com/hack/stock2u/global/config/WebConfig.java
@@ -1,16 +1,25 @@
 package com.hack.stock2u.global.config;
 
 import com.hack.stock2u.authentication.service.AuthVendorEnumConverter;
+import com.hack.stock2u.global.filter.RoleGuardInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+  private final RoleGuardInterceptor roleGuardInterceptor;
 
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new AuthVendorEnumConverter());
   }
 
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(roleGuardInterceptor);
+  }
 }

--- a/src/main/java/com/hack/stock2u/global/filter/BasicLogFilter.java
+++ b/src/main/java/com/hack/stock2u/global/filter/BasicLogFilter.java
@@ -1,0 +1,16 @@
+package com.hack.stock2u.global.filter;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class BasicLogFilter extends Filter<ILoggingEvent> {
+  @Override
+  public FilterReply decide(ILoggingEvent event) {
+    String loggerName = event.getLoggerName();
+    if (loggerName.equals(HttpLogger.class.getName())) {
+      return FilterReply.DENY;
+    }
+    return FilterReply.ACCEPT;
+  }
+}

--- a/src/main/java/com/hack/stock2u/global/filter/HttpFilter.java
+++ b/src/main/java/com/hack/stock2u/global/filter/HttpFilter.java
@@ -1,0 +1,15 @@
+package com.hack.stock2u.global.filter;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class HttpFilter extends Filter<ILoggingEvent> {
+  @Override
+  public FilterReply decide(ILoggingEvent event) {
+    if (event.getLoggerName().equals(HttpLogger.class.getName())) {
+      return FilterReply.ACCEPT;
+    }
+    return FilterReply.DENY;
+  }
+}

--- a/src/main/java/com/hack/stock2u/global/filter/HttpLogger.java
+++ b/src/main/java/com/hack/stock2u/global/filter/HttpLogger.java
@@ -1,6 +1,8 @@
 package com.hack.stock2u.global.filter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -9,11 +11,31 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @Component
 public class HttpLogger extends OncePerRequestFilter {
+  private final List<String> excludeAntPaths = Arrays.asList(
+      "/api/swagger-ui/**", "/api/docs/**", "/api/api-docs/**"
+  );
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String requestUri = request.getRequestURI();
+    AntPathMatcher matcher = new AntPathMatcher();
+
+    for (var path : excludeAntPaths) {
+      boolean match = matcher.match(path, requestUri);
+      if (match) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   @Override
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain
@@ -28,6 +50,7 @@ public class HttpLogger extends OncePerRequestFilter {
       log.debug("[{}] {}", method, requestUri);
       response.setHeader("X-Trace-Id", traceId);
       MDC.clear();
+      filterChain.doFilter(request, response);
     } catch (Exception ex) {
       log.error("error: {}\n{}", ex.getMessage(), ex.getStackTrace());
     }

--- a/src/main/java/com/hack/stock2u/global/filter/HttpLogger.java
+++ b/src/main/java/com/hack/stock2u/global/filter/HttpLogger.java
@@ -1,0 +1,36 @@
+package com.hack.stock2u.global.filter;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class HttpLogger extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain
+  ) throws ServletException, IOException {
+    try {
+      String traceId = RandomStringUtils.randomAlphabetic(8);
+      MDC.put("traceId", traceId);
+
+      String method = request.getMethod();
+      String requestUri = request.getRequestURI();
+
+      log.debug("[{}] {}", method, requestUri);
+      response.setHeader("X-Trace-Id", traceId);
+      MDC.clear();
+    } catch (Exception ex) {
+      log.error("error: {}\n{}", ex.getMessage(), ex.getStackTrace());
+    }
+
+  }
+}

--- a/src/main/java/com/hack/stock2u/global/filter/RoleGuardInterceptor.java
+++ b/src/main/java/com/hack/stock2u/global/filter/RoleGuardInterceptor.java
@@ -1,0 +1,29 @@
+package com.hack.stock2u.global.filter;
+
+import com.hack.stock2u.utils.RoleGuard;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+public class RoleGuardInterceptor implements HandlerInterceptor {
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler
+  ) throws Exception {
+    HandlerMethod handlerMethod = (HandlerMethod) handler;
+    RoleGuard roleGuard = handlerMethod.getMethodAnnotation(RoleGuard.class);
+    if (roleGuard == null) {
+      return true;
+    }
+
+    HttpSession session = request.getSession();
+    log.debug("{}", session.getAttributeNames());
+    return false;
+  }
+}

--- a/src/main/java/com/hack/stock2u/product/api/ProductApi.java
+++ b/src/main/java/com/hack/stock2u/product/api/ProductApi.java
@@ -1,8 +1,10 @@
 package com.hack.stock2u.product.api;
 
+import com.hack.stock2u.constant.UserRole;
 import com.hack.stock2u.product.dto.ProductDetails;
 import com.hack.stock2u.product.dto.ProductRequest;
 import com.hack.stock2u.product.service.ProductService;
+import com.hack.stock2u.utils.RoleGuard;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductApi {
   private final ProductService productService;
 
+  @RoleGuard(roles = UserRole.SELLER)
   @Operation(summary = "잔여 재고 게시글 생성 API", description = "잔여 재고 게시글을 생성하고 생성된 객체를 반환합니다.")
   @PostMapping
   public ResponseEntity<ProductDetails> createProductApi(

--- a/src/main/java/com/hack/stock2u/utils/RoleGuard.java
+++ b/src/main/java/com/hack/stock2u/utils/RoleGuard.java
@@ -1,0 +1,13 @@
+package com.hack.stock2u.utils;
+
+import com.hack.stock2u.constant.UserRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RoleGuard {
+  UserRole[] roles() default {UserRole.SELLER, UserRole.ADMIN, UserRole.PURCHASER};
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,7 @@ springdoc:
     path: /docs
     tags-sorter: alpha
     operations-sorter: alpha
+    with-credentials: true
 
 logging:
   level:
@@ -89,6 +90,8 @@ logging:
     com.amazonaws.util.EC2MetadataUtils: ERROR
     com.amazonaws.internal.EC2ResourceFetcher: ERROR
     org.apache.http.wire: WARN
+  config: classpath:logback-spring.xml
+
 # local 환경
 ---
 spring:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,7 +5,7 @@
     <appender name="RollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOGS}/ldata.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>log/ldata.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>logs/ldata.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -16,6 +16,7 @@
     </appender>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="com.hack.stock2u.global.filter.BasicLogFilter" />
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>
                 [%d{HH:mm:ss.SSS}] %cyan([%thread]) %highlight(%-5level) %green(%logger) %msg%n
@@ -23,7 +24,22 @@
         </encoder>
     </appender>
 
+    <appender name="HTTP" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="com.hack.stock2u.global.filter.HttpFilter" />
+        <!--        <file>${LOGS}/http.log</file>-->
+        <!--        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">-->
+        <!--            <fileNamePattern>logs/http.%d{yyyy-MM-dd}.log</fileNamePattern>-->
+        <!--            <maxHistory>30</maxHistory>-->
+        <!--        </rollingPolicy>-->
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>
+                [%d{HH:mm:ss.SSS}] %highlight(%-5level) %green(%logger) %red([traceId=%X{traceId}]) - %cyan(%msg%n)
+            </Pattern>
+        </encoder>
+    </appender>
+
     <root level="debug">
+        <appender-ref ref="HTTP" />
         <appender-ref ref="RollingFile" />
         <appender-ref ref="Console" />
     </root>


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-103](https://geezers-io.atlassian.net/browse/SU-103)
Implements [issue SU-106](https://geezers-io.atlassian.net/browse/SU-106)

## What & Why
* 원활한 디버깅을 위한 HTTP 로깅을 추가하였습니다.
앞으로 에러 발생 시 요청에 대한 TraceId 로 요청을 쉽게 추적할 수 있습니다.

프런트엔드에서 에러가 발생한다면 TraceId 를 공유함으로써
에러 발생 원인 자체를 적은 커뮤니케이션으로 쉽게 추적할 수 있습니다.
(다만 요청할 때 Url Parameter, Request body 등 값은 추적할 수 없는 관계로 복잡한 요청의 경우 전문 공유가 나을 수 있습니다.)

> 단순한 에러에 대한 행위에 근본적 원인을 추적하기 위함

<img width="334" alt="image" src="https://github.com/geezers-io/Stock2U-api/assets/50310464/1d5cbf12-9f4f-4bf2-b0f1-533d516c79b1">

> X-Trace-Id 값 참조 ( Response Header 내 포함 )



* API 별로 권한을 체크하는 편의성 기능을 추가하였습니다.
예제 코드입니다.
```java
@Tag(name = "P. 잔여 재고 API")
@RequiredArgsConstructor
@RestController
@RequestMapping("/products")
public class ProductApi {
  private final ProductService productService;

  @RoleGuard(roles = {UserRole.SELLER}) <-- 어노테이션 주목
  @Operation(summary = "잔여 재고 게시글 생성 API", description = "잔여 재고 게시글을 생성하고 생성된 객체를 반환합니다.")
  @PostMapping
  public ResponseEntity<ProductDetails> createProductApi(
      @RequestBody @Valid ProductRequest.Create createRequest
  ) {
    ProductDetails productDetails = productService.create(createRequest);
    return ResponseEntity.status(HttpStatus.CREATED).body(productDetails);
  }
}

```

`@RoleGuard` 라는 어노테이션을 컨트롤러 메서드에 붙이게되면,
해당 api 로직을 수행하기전에 요청한 사용자가 해당 권한을 가지고 있는 지
세부적으로 점검할 수 있습니다.

단일 권한을 점검할 경우 다음과 같이 유연하게 사용할 수도 있습니다.
` @RoleGuard(roles = UserRole.PURCHASER)
`

## Checklist
- [ ] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
