### PR TITLE
feat: 일반 사용자 채팅 내역 리스트

### DIFF
--- a/src/main/java/com/hack/stock2u/chat/api/MessageController.java
+++ b/src/main/java/com/hack/stock2u/chat/api/MessageController.java
@@ -1,7 +1,6 @@
 package com.hack.stock2u.chat.api;
 
 import com.hack.stock2u.chat.service.ChatMessageService;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
+++ b/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
@@ -3,24 +3,32 @@ package com.hack.stock2u.chat.api;
 import com.hack.stock2u.chat.dto.ReservationProductPurchaser;
 import com.hack.stock2u.chat.dto.request.ReportRequest;
 import com.hack.stock2u.chat.dto.request.ReservationApproveRequest;
+import com.hack.stock2u.chat.dto.response.PurchaserReservationsResponse;
 import com.hack.stock2u.chat.dto.response.ReservationResponse;
+import com.hack.stock2u.chat.dto.response.SimpleReservation;
 import com.hack.stock2u.chat.service.ChatMessageService;
 import com.hack.stock2u.chat.service.ReservationService;
 import com.hack.stock2u.constant.ReservationStatus;
 import com.hack.stock2u.constant.UserRole;
+import com.hack.stock2u.models.Reservation;
 import com.hack.stock2u.utils.RoleGuard;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "C. 예약 API (채팅, 재고 관련)")
@@ -72,13 +80,28 @@ public class ReservationApi {
   }
 
   @Operation(summary = "신고 API", description = "채팅방에서 사용자 신고 API")
-  @PostMapping("/room/report")
+  @PostMapping("/report")
   public ResponseEntity<Short> reportUserApi(@RequestBody @Valid ReportRequest request) {
     Short reportCount = reservationService.report(request);
     return ResponseEntity.status(HttpStatus.OK).body(reportCount);
   }
 
-  //  @Operation(summary = "채팅방 조회 API", description = "특정 이용자의 채팅 내역 조회")
-  //  @GetMapping("/rooms")
-  //  public ResponseEntity<>
+  @RoleGuard(roles = UserRole.PURCHASER)
+  @Operation(summary = "일반 사용자 채팅방 조회 API", description = "일반 사용자의 채팅 내역 조회")
+  @GetMapping("/purchaser/reservations")
+  public ResponseEntity<Page<PurchaserReservationsResponse>> getAllPurchaserReservations(
+      @Parameter(description = "조회할 페이지 넘버(0부터 시작)", required = true)
+      @RequestParam("page") int page,
+      @Parameter(description = "가져올 데이터 갯수 단위", required = true)
+      @RequestParam("size") int size
+  ) {
+    PageRequest pageable = PageRequest.of(page, size);
+    Page<PurchaserReservationsResponse> purchaserReservations =
+        reservationService.getPurchaserReservations(pageable);
+    return ResponseEntity.status(HttpStatus.OK).body(purchaserReservations);
+  }
+
+
+
+
 }

--- a/src/main/java/com/hack/stock2u/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/ChatMessageResponse.java
@@ -12,13 +12,19 @@ public record ChatMessageResponse(
     @Schema(required = true, description = "chatmessage에 id")
     @NotNull
     Long roomId,
-
-    Long userId,
     String username,
     String message,
     Date createdAt
 
 //    String image
 ) {
-
+  public static ChatMessageResponse create(
+      ChatMessage chatMessage) {
+    return ChatMessageResponse.builder()
+        .roomId(chatMessage.getRoomId())
+        .username(chatMessage.getUserName())
+        .message(chatMessage.getMessage())
+        .createdAt(chatMessage.getCreatedAt())
+        .build();
+  }
 }

--- a/src/main/java/com/hack/stock2u/chat/dto/response/PurchaserReservationsResponse.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/PurchaserReservationsResponse.java
@@ -1,0 +1,8 @@
+package com.hack.stock2u.chat.dto.response;
+
+
+public record PurchaserReservationsResponse(
+    ChatMessageResponse chatMessageResponse,
+    SimpleReservation simpleReservation
+
+) {}

--- a/src/main/java/com/hack/stock2u/chat/dto/response/SimpleReservation.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/SimpleReservation.java
@@ -1,0 +1,32 @@
+package com.hack.stock2u.chat.dto.response;
+
+import com.hack.stock2u.constant.ReservationStatus;
+import com.hack.stock2u.file.dto.SimpleFile;
+import com.hack.stock2u.models.Attach;
+import com.hack.stock2u.models.Reservation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record SimpleReservation(
+
+    @Schema(description = "예약 id")
+    Long id,
+    @Schema(description = "상품 이름")
+    String name,
+    @Schema(description = "예약 상태")
+    ReservationStatus status,
+    @Schema(description = "썸네일 주소")
+    SimpleThumbnailImage uploadUrl
+) {
+  public static SimpleReservation create(Reservation reservation,
+                                         SimpleThumbnailImage simpleThumbnailImage) {
+    return SimpleReservation.builder()
+        .id(reservation.getId())
+        .name(reservation.getName())
+        .status(reservation.getStatus())
+        .uploadUrl(simpleThumbnailImage)
+        .build();
+  }
+}

--- a/src/main/java/com/hack/stock2u/chat/dto/response/SimpleThumbnailImage.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/SimpleThumbnailImage.java
@@ -1,0 +1,10 @@
+package com.hack.stock2u.chat.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SimpleThumbnailImage(
+
+    String uploadPath
+) {
+}

--- a/src/main/java/com/hack/stock2u/chat/repository/JpaReservationRepository.java
+++ b/src/main/java/com/hack/stock2u/chat/repository/JpaReservationRepository.java
@@ -2,11 +2,17 @@ package com.hack.stock2u.chat.repository;
 
 import com.hack.stock2u.models.Reservation;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaReservationRepository extends JpaRepository<Reservation, Long> {
-  List<Reservation> findByNameContaining(String productName);
+
+  Page<Reservation> findBySellerId(Long sellerId, Pageable pageable);
+
+  Page<Reservation> findByPurchaserId(Long purchaserId, Pageable pageable);
 
 }

--- a/src/main/java/com/hack/stock2u/chat/repository/MessageChatMongoRepository.java
+++ b/src/main/java/com/hack/stock2u/chat/repository/MessageChatMongoRepository.java
@@ -12,5 +12,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MessageChatMongoRepository extends MongoRepository<ChatMessage, String> {
 
-  Optional<ChatMessage> findByRoomIdOrderByTimestampDesc(Long id, PageRequest of);
+  Optional<ChatMessage> findByRoomIdOrderByCreatedAtDesc(Long id, PageRequest of);
 }

--- a/src/main/java/com/hack/stock2u/chat/repository/MessageChatMongoRepository.java
+++ b/src/main/java/com/hack/stock2u/chat/repository/MessageChatMongoRepository.java
@@ -2,12 +2,15 @@ package com.hack.stock2u.chat.repository;
 
 import com.hack.stock2u.models.ChatMessage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MessageChatMongoRepository extends MongoRepository<ChatMessage, String> {
-  
+
+  Optional<ChatMessage> findByRoomIdOrderByTimestampDesc(Long id, PageRequest of);
 }

--- a/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
@@ -120,12 +120,13 @@ public class ReservationService {
 
   private PurchaserReservationsResponse purchaserReservationLatestMessages(Long id) {
     ChatMessage chatMessage = chatMongoRepository
-        .findByRoomIdOrderByTimestampDesc(id, PageRequest.of(0, 1))
+        .findByRoomIdOrderByCreatedAtDesc(id, PageRequest.of(0, 1))
          .orElseThrow(GlobalException.NOT_FOUND::create);
     ChatMessageResponse messageResponse = ChatMessageResponse.create(chatMessage);
     Reservation reservation = reservationRepository.findById(id)
          .orElseThrow(GlobalException.NOT_FOUND::create);
-    Attach thumbnail = attachRepository.getThumbnail(reservation.getProduct().getId());
+    Attach thumbnail = attachRepository.findFirstByProductIdOrderById(
+        reservation.getProduct().getId());
     SimpleThumbnailImage simpleThumbnailImage = SimpleThumbnailImage.builder()
         .uploadPath(thumbnail.getUploadPath())
         .build();

--- a/src/main/java/com/hack/stock2u/file/repository/JpaAttachRepository.java
+++ b/src/main/java/com/hack/stock2u/file/repository/JpaAttachRepository.java
@@ -2,5 +2,9 @@ package com.hack.stock2u.file.repository;
 
 import com.hack.stock2u.models.Attach;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface JpaAttachRepository extends JpaRepository<Attach, Long> {}
+public interface JpaAttachRepository extends JpaRepository<Attach, Long> {
+  @Query("select a from attachments a where a.product.id = :productId order by a.id limit 1")
+  Attach getThumbnail(Long productId);
+}

--- a/src/main/java/com/hack/stock2u/file/repository/JpaAttachRepository.java
+++ b/src/main/java/com/hack/stock2u/file/repository/JpaAttachRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface JpaAttachRepository extends JpaRepository<Attach, Long> {
-  @Query("select a from attachments a where a.product.id = :productId order by a.id limit 1")
-  Attach getThumbnail(Long productId);
+  Attach findFirstByProductIdOrderById(Long productId);
+
 }

--- a/src/main/java/com/hack/stock2u/models/Reservation.java
+++ b/src/main/java/com/hack/stock2u/models/Reservation.java
@@ -53,7 +53,7 @@ public class Reservation {
 
   @Comment("구매자 id")
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "customer_id")
+  @JoinColumn(name = "purchaser_id")
   private User purchaser;
 
   @Column(name = "disabled_at")


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-90](https://geezers-io.atlassian.net/browse/SU-90)

## What & Why
![image](https://github.com/geezers-io/Stock2U-api/assets/82084599/48aca701-e4e4-4963-8f66-8ea23005e529)
구매자 채팅 내역 리스트 불러오는 API를 작성했습니다. 
하지만 부득이 하게 판매자, 구매자 나누어 API를 작성했습니다.
![image](https://github.com/geezers-io/Stock2U-api/assets/82084599/a0e1c01f-0017-4484-ac12-8e15bc0d5246)
SessionManager로 id를 얻었을때 sellerid와 purchaserid를 두개 중에 포함된 id로 reservation을 가져오는데 귀찮지만 나눠서 하는게 쉬울거 같아서 일단 나눴습니다.
![image](https://github.com/geezers-io/Stock2U-api/assets/82084599/a091a0d9-36b2-440c-8f18-432ba00039ea)
pagination 처음해보니깐 정말 어렵네요 덕분에 stream많이 공부하는듯
코드 리뷰 부탁드립니다. 맞게 짠건지 제가 보기엔 db접근을 쓸때없이 많이한거 같기도합니다.
## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
