### PR TITLE
feat: 구매자 판매자 공통 채팅 조회 로직 구현

### DIFF
--- a/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
+++ b/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
@@ -3,14 +3,12 @@ package com.hack.stock2u.chat.api;
 import com.hack.stock2u.chat.dto.ReservationProductPurchaser;
 import com.hack.stock2u.chat.dto.request.ReportRequest;
 import com.hack.stock2u.chat.dto.request.ReservationApproveRequest;
-import com.hack.stock2u.chat.dto.response.PurchaserReservationsResponse;
+import com.hack.stock2u.chat.dto.response.PurchaserSellerReservationsResponse;
 import com.hack.stock2u.chat.dto.response.ReservationResponse;
-import com.hack.stock2u.chat.dto.response.SimpleReservation;
 import com.hack.stock2u.chat.service.ChatMessageService;
 import com.hack.stock2u.chat.service.ReservationService;
 import com.hack.stock2u.constant.ReservationStatus;
 import com.hack.stock2u.constant.UserRole;
-import com.hack.stock2u.models.Reservation;
 import com.hack.stock2u.utils.RoleGuard;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -86,22 +84,34 @@ public class ReservationApi {
     return ResponseEntity.status(HttpStatus.OK).body(reportCount);
   }
 
-  @RoleGuard(roles = UserRole.PURCHASER)
-  @Operation(summary = "일반 사용자 채팅방 조회 API", description = "일반 사용자의 채팅 내역 조회")
-  @GetMapping("/purchaser/reservations")
-  public ResponseEntity<Page<PurchaserReservationsResponse>> getAllPurchaserReservations(
+
+  @Operation(summary = "공통 채팅방 조회 API", description = "일반 사용자의 채팅 내역 조회")
+  @GetMapping("/reservations")
+  public ResponseEntity<Page<PurchaserSellerReservationsResponse>> getAllPurchaserReservations(
       @Parameter(description = "조회할 페이지 넘버(0부터 시작)", required = true)
       @RequestParam("page") int page,
       @Parameter(description = "가져올 데이터 갯수 단위", required = true)
       @RequestParam("size") int size
   ) {
     PageRequest pageable = PageRequest.of(page, size);
-    Page<PurchaserReservationsResponse> purchaserReservations =
-        reservationService.getPurchaserReservations(pageable);
+    Page<PurchaserSellerReservationsResponse> purchaserReservations =
+        reservationService.getReservations(pageable);
     return ResponseEntity.status(HttpStatus.OK).body(purchaserReservations);
   }
 
 
-
-
+  //  @Operation(summary = "검색으로 채팅방 조회 API", description = "공통 채팅방 검색 조회")
+  //  public ResponseEntity<Page<PurchaserSellerReservationsResponse>>  getReservationsBySearch(
+  //      @Parameter(description = "게시글 제목으로 검색")
+  //      @RequestParam("title") String title,
+  //      @Parameter(description = "조회할 페이지 넘버(0부터 시작)", required = true)
+  //      @RequestParam("page") int page,
+  //      @Parameter(description = "가져올 데이터 갯수 단위", required = true)
+  //      @RequestParam("size") int size
+  //  ) {
+  //    PageRequest pageable = PageRequest.of(page, size);
+  //    Page<PurchaserSellerReservationsResponse> purchaserReservations =
+  //        reservationService.search(pageable, title);
+  //    return ResponseEntity.status(HttpStatus.OK).body(purchaserReservations);
+  //  }
 }

--- a/src/main/java/com/hack/stock2u/chat/dto/response/PurchaserSellerReservationsResponse.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/PurchaserSellerReservationsResponse.java
@@ -1,7 +1,7 @@
 package com.hack.stock2u.chat.dto.response;
 
 
-public record PurchaserReservationsResponse(
+public record PurchaserSellerReservationsResponse(
     ChatMessageResponse chatMessageResponse,
     SimpleReservation simpleReservation
 

--- a/src/main/java/com/hack/stock2u/chat/repository/JpaReservationRepository.java
+++ b/src/main/java/com/hack/stock2u/chat/repository/JpaReservationRepository.java
@@ -13,6 +13,9 @@ public interface JpaReservationRepository extends JpaRepository<Reservation, Lon
 
   Page<Reservation> findBySellerId(Long sellerId, Pageable pageable);
 
+  Optional<Reservation> findBySellerId(Long sellerId);
+
   Page<Reservation> findByPurchaserId(Long purchaserId, Pageable pageable);
 
+  Optional<Reservation> findByPurchaserId(Long purchaser);
 }

--- a/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
@@ -146,7 +146,6 @@ public class ReservationService {
         reservation, simpleThumbnailImage);
     return new PurchaserSellerReservationsResponse(messageResponse, simpleReservation);
   }
-  
   //  public Page<PurchaserSellerReservationsResponse> search(PageRequest pageable, String title) {
   //
   //

--- a/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
@@ -146,8 +146,7 @@ public class ReservationService {
         reservation, simpleThumbnailImage);
     return new PurchaserSellerReservationsResponse(messageResponse, simpleReservation);
   }
-
-
+  
   //  public Page<PurchaserSellerReservationsResponse> search(PageRequest pageable, String title) {
   //
   //


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-90](https://geezers-io.atlassian.net/browse/SU-90)

## What & Why
어제 구매자 채팅 조회랑 판매자 채팅 조회를 나누어서 작업을 했는데 겹치는 부분이 많아서 합치는 작업을 했습니다.(누군지 체크하는 메소드 생성함)
하지만 id로 판매자인지 구매자인지 검사하는 과정에서 사용자, 판매자로 나눠서 로직을 짰을때 보다 DB접근 비용이 더 발생합니다. 그래서 뭐가 더 나은지 궁금합니다. 그리고 개선할 수 있는방법이 있는지도 궁금합니다.
![image](https://github.com/geezers-io/Stock2U-api/assets/82084599/9519b0a4-d808-42f7-85bd-63ad5d8b480f)
### fix:
![image](https://github.com/geezers-io/Stock2U-api/assets/82084599/80ca79d1-ca92-405d-a5a7-1bef2b0504a5)


## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
