### PR TITLE
feat: 재고 관련 이슈 해결 / 재고 조회 API  요구사항 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    implementation 'org.webjars:sockjs-client:1.1.2'
     implementation 'org.webjars:stomp-websocket:2.3.3-1'
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
@@ -109,7 +108,7 @@ checkstyleMain {
 }
 
 clean {
-    delete file('src/main/generated')
+    delete file(querydslDir)
 }
 
 checkstyleTest {

--- a/src/main/java/com/hack/stock2u/models/Subscription.java
+++ b/src/main/java/com/hack/stock2u/models/Subscription.java
@@ -20,12 +20,12 @@ public class Subscription {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Comment("판매자(사업자) id")
+  @Comment("구매자 id")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "subscriber_id")
   private User subscriber;
 
-  @Comment("구매자(예약자) id")
+  @Comment("판매자 id")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "target_id")
   private User target;

--- a/src/main/java/com/hack/stock2u/product/dto/ProductCountProjection.java
+++ b/src/main/java/com/hack/stock2u/product/dto/ProductCountProjection.java
@@ -1,0 +1,11 @@
+package com.hack.stock2u.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.hack.stock2u.constant.ProductType;
+import java.util.Date;
+
+public interface ProductCountProjection {
+  Long getTotalCount();
+
+  Double getDistance();
+}

--- a/src/main/java/com/hack/stock2u/product/dto/ProductDetails.java
+++ b/src/main/java/com/hack/stock2u/product/dto/ProductDetails.java
@@ -23,10 +23,13 @@ public record ProductDetails(
     @Schema(description = "예약 상태(예약 한 건만 받기 체크 && 예약 진행 중일 시 표기 됨)", nullable = true)
     ReservationStatus status,
     SellerDetails seller,
+
+    @Schema(description = "요청한 사용자(구매자)가 구독한 판매자인 지 여부 (true 면 구독)")
+    boolean isSubscribe,
     List<SimpleFile> productImages
 ) {
   public static ProductDetails create(
-      Product p, SellerDetails sellerDetails, List<Attach> attaches
+      Product p, SellerDetails sellerDetails, List<Attach> attaches, boolean isSubscribe
   ) {
     List<SimpleFile> simpleFiles = attaches.stream().map(SimpleFile::attach).toList();
     return ProductDetails.builder()
@@ -39,6 +42,7 @@ public record ProductDetails(
         .productCount(p.getProductCount())
         .seller(sellerDetails)
         .productImages(simpleFiles)
+        .isSubscribe(isSubscribe)
         .build();
   }
 }

--- a/src/main/java/com/hack/stock2u/user/dto/SellerDetails.java
+++ b/src/main/java/com/hack/stock2u/user/dto/SellerDetails.java
@@ -9,16 +9,18 @@ public record SellerDetails(
     Long id,
     String username,
     String phone,
+    String profileImageUrl,
     @Schema(description = "판매 재고 갯수", required = true)
     int salesCount,
     @Schema(description = "받은 리뷰 갯수", required = true)
     int reviewCount
 ) {
-  public static SellerDetails create(User u, int salesCount, int reviewCount) {
+  public static SellerDetails create(User u, String profileImageUrl, int salesCount, int reviewCount) {
     return SellerDetails.builder()
         .id(u.getId())
         .username(u.getName())
         .phone(u.getPhone())
+        .profileImageUrl(profileImageUrl)
         .salesCount(salesCount)
         .reviewCount(reviewCount)
         .build();

--- a/src/main/java/com/hack/stock2u/user/dto/SellerDetails.java
+++ b/src/main/java/com/hack/stock2u/user/dto/SellerDetails.java
@@ -15,7 +15,9 @@ public record SellerDetails(
     @Schema(description = "받은 리뷰 갯수", required = true)
     int reviewCount
 ) {
-  public static SellerDetails create(User u, String profileImageUrl, int salesCount, int reviewCount) {
+  public static SellerDetails create(
+      User u, String profileImageUrl, int salesCount, int reviewCount
+  ) {
     return SellerDetails.builder()
         .id(u.getId())
         .username(u.getName())

--- a/src/main/java/com/hack/stock2u/user/repository/JpaSubscriptionRepository.java
+++ b/src/main/java/com/hack/stock2u/user/repository/JpaSubscriptionRepository.java
@@ -21,4 +21,6 @@ public interface JpaSubscriptionRepository extends JpaRepository<Subscription, L
   Optional<Long> findByUserIds(Long uid, Long sellerId);
 
   Page<Subscription> findBySubscriberId(Long id, Pageable pageable);
+
+  Optional<Long> findBySubscriberId(Long purchaserId);
 }

--- a/src/main/java/com/hack/stock2u/user/service/SellerService.java
+++ b/src/main/java/com/hack/stock2u/user/service/SellerService.java
@@ -1,6 +1,9 @@
 package com.hack.stock2u.user.service;
 
 import com.hack.stock2u.authentication.service.SessionManager;
+import com.hack.stock2u.file.repository.JpaAttachRepository;
+import com.hack.stock2u.global.exception.GlobalException;
+import com.hack.stock2u.models.Attach;
 import com.hack.stock2u.models.SellerDetails;
 import com.hack.stock2u.models.User;
 import com.hack.stock2u.user.dto.AvatarId;
@@ -22,6 +25,7 @@ public class SellerService {
   private final SessionManager sessionManager;
   private final SellerDslRepository sellerDslRepository;
   private final UserDslRepository userDslRepository;
+  private final JpaAttachRepository attachRepository;
 
   public SellerSummary getDetails() {
     User user = sessionManager.getSessionUserByRdb();
@@ -54,7 +58,11 @@ public class SellerService {
   // FIX: 리뷰 미구현으로 갯수 0 고정
   public com.hack.stock2u.user.dto.SellerDetails getSellerDetails(User u) {
     int salesCount = getSalesCount(u);
-    return com.hack.stock2u.user.dto.SellerDetails.create(u, salesCount, 0);
+    Attach avatar = attachRepository.findById(u.getAvatarId())
+        .orElseThrow(GlobalException.NOT_FOUND::create);
+    return com.hack.stock2u.user.dto.SellerDetails.create(
+        u, avatar.getUploadPath(), salesCount, 0
+    );
   }
 
   public void updateLocation(SellerRequest.LocationUpdate locationUpdateRequest) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,7 +20,6 @@ cloud:
     stack:
       auto: false
 
-
 spring:
   profiles:
     group:
@@ -79,7 +78,6 @@ logging:
     com.zaxxer.hikari: INFO
     io.netty: INFO
     org.springframework.context.annotation: INFO
-    org.hibernate.type.descriptor.sql: DEBUG
     org.hibernate.sql: DEBUG
     org.hibernate.type: TRACE
     org.hibernate.hql.internal.ast: WARN
@@ -127,7 +125,7 @@ spring:
     store-type: redis
     redis:
       namespace: stock2u:session
-    timeout: 1h
+    timeout: 60m
 
 
 # dev 환경
@@ -149,6 +147,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+  output:
+    ansi:
+      enabled: always
     database: mysql
     properties:
       hibernate:


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
재고 API

1. thumbnailUrl null 해결 완료
2. totalCount 이슈 수정 완료
3. 재고 조회 API - sellerDetails 에 profileImageUrl 추가(판매자 아바타 이미지)
4. 재고 조회 API - isSubscribe 추가 - (요청한 구매자와 해당 게시글 판매자간 구독 여부) - swagger 참조

## Checklist
- [ ] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
