### PR TITLE
feat: 예약(채팅) - [BE] 각 사용자에 대한 알람 채널 생성 및 구독 API

### DIFF
--- a/src/main/java/com/hack/stock2u/chat/config/CredentialsInterceptor.java
+++ b/src/main/java/com/hack/stock2u/chat/config/CredentialsInterceptor.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -23,8 +22,15 @@ public class CredentialsInterceptor implements ChannelInterceptor {
   @Override
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
     StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    log.info(message.getHeaders().toString());
     List<String> userIds = accessor.getNativeHeader("userId");
     List<String> phones = accessor.getNativeHeader("phone");
+
+    if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+      return ChannelInterceptor.super.preSend(message, channel);
+    }
+
+    log.info("userIds: {}, phones: {}", userIds, phones);
     if (userIds == null || phones == null) {
       throw AuthException.IS_ANONYMOUS_USER.create();
     }

--- a/src/main/java/com/hack/stock2u/chat/service/ReservationMessageHandler.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ReservationMessageHandler.java
@@ -1,0 +1,29 @@
+package com.hack.stock2u.chat.service;
+
+import com.hack.stock2u.constant.MessageTemplate;
+import java.text.MessageFormat;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReservationMessageHandler {
+  private final SimpMessagingTemplate publisher;
+
+  /**
+   * 예약 생성에 대한 메시지를 발송합니다.
+
+   * @param pid 구매자 ID
+   * @param sid 판매자 ID
+   */
+  public void publishReservationRequest(String title, Long pid, Long sid) {
+    String message = MessageFormat.format(MessageTemplate.RESERVATION_REQUEST.getMessage(), title);
+    String dest = "/topic/alert/";
+    publisher.convertAndSend(dest + pid, message);
+    publisher.convertAndSend(dest + sid, message);
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
@@ -31,13 +31,16 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
@@ -50,6 +53,7 @@ public class ReservationService {
   private final JpaAttachRepository attachRepository;
   private final SessionManager sessionManager;
   private final JpaReportRepository reportRepository;
+  private final ReservationMessageHandler reservationMessageHandler;
 
   /**
    * 예약 엔티티를 생성합니다.
@@ -72,6 +76,12 @@ public class ReservationService {
             .chatId(roomId)
             .seller(product.getSeller())
             .build()
+    );
+
+    reservationMessageHandler.publishReservationRequest(
+        product.getTitle(),
+        purchaser.getId(),
+        product.getSeller().getId()
     );
 
     return new ReservationProductPurchaser(reservation, product, purchaser);

--- a/src/main/java/com/hack/stock2u/constant/MessageTemplate.java
+++ b/src/main/java/com/hack/stock2u/constant/MessageTemplate.java
@@ -1,0 +1,18 @@
+package com.hack.stock2u.constant;
+
+public enum MessageTemplate {
+  RESERVATION_REQUEST("""
+  "{0}" 재고 예약이 요청되었습니다
+  """);
+
+  private final String message;
+
+  MessageTemplate(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/global/config/RedisConfig.java
+++ b/src/main/java/com/hack/stock2u/global/config/RedisConfig.java
@@ -1,7 +1,6 @@
 package com.hack.stock2u.global.config;
 
 
-import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +9,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Slf4j


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-137](https://geezers-io.atlassian.net/browse/SU-137)

## What & Why
사용자마다 채널을 생성하고 구독하며
단방향으로 전달목적인 알림을 발송하는 로직을 작성하였습니다.
또한 기존 비즈니스 로직에 결합되어있었던 메시지 발송 로직의 객체의 책임을 분리하였습니다.

작업하다보니 사용자마다 채널 하나를 수용하는게 최선의 구조인 지 의문이드네요.
모든 사용자를 한 채널에 수용하고 SendToUser 기능을 사용해서 특정 사용자에게 전달하는게 좋은것같은데
어떻게 그렇게 구현해야하는 지 어려움을 겪었습니다.

## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
