### PR TITLE
Feature: 카운팅+룸id 메세지로 전달, 기존 메세지에서 보내야할 정보 objectmapper로 직렬화

### DIFF
--- a/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
+++ b/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
@@ -1,6 +1,7 @@
 package com.hack.stock2u.chat.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hack.stock2u.chat.dto.ReservationApproveToMessage;
 import com.hack.stock2u.chat.dto.ReservationProductPurchaser;
 import com.hack.stock2u.chat.dto.request.ChangeStatusRequest;
 import com.hack.stock2u.chat.dto.request.ReportRequest;
@@ -64,9 +65,9 @@ public class ReservationApi {
   public ResponseEntity<ReservationStatus> approveReservationApi(
       ReservationApproveRequest request) {
 
-    ReservationStatus approve = reservationService.approve(request);
-    chatMessageService.saveAndSendAutoMessageApprove(request);
-    return ResponseEntity.status(HttpStatus.OK).body(approve);
+    ReservationApproveToMessage approveToMessage = reservationService.approve(request);
+    chatMessageService.saveAndSendAutoMessageApprove(approveToMessage);
+    return ResponseEntity.status(HttpStatus.OK).body(approveToMessage.status());
   }
   //이게 채팅방을 삭제하는건데 로직을 예약 취소로 작성해버림 수정 필요
 

--- a/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
+++ b/src/main/java/com/hack/stock2u/chat/api/ReservationApi.java
@@ -1,5 +1,6 @@
 package com.hack.stock2u.chat.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hack.stock2u.chat.dto.ReservationProductPurchaser;
 import com.hack.stock2u.chat.dto.request.ChangeStatusRequest;
 import com.hack.stock2u.chat.dto.request.ReportRequest;
@@ -50,9 +51,9 @@ public class ReservationApi {
       @PathVariable("productId") Long productId
   ) {
     ReservationProductPurchaser ret = reservationService.create(productId);
-    // 예약 눌렀을때 메세지 보내지는 방식
-    // 상태 보내야함 근데 null로 갈꺼 같음 그래서 상태 하나 추가해야될듯?
-    // 메세지로 ReservationStatus를 넘기는게 맞을까? 구매자가 판매자에게 넘기는 형식임
+    if (ret == null) {
+      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
     chatMessageService.saveAndSendAutoMessage(ret);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }

--- a/src/main/java/com/hack/stock2u/chat/config/ObjectMapperConfig.java
+++ b/src/main/java/com/hack/stock2u/chat/config/ObjectMapperConfig.java
@@ -1,0 +1,19 @@
+package com.hack.stock2u.chat.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.val;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    return mapper;
+  }
+}

--- a/src/main/java/com/hack/stock2u/chat/dto/ChatMessageObjectForSerialize.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/ChatMessageObjectForSerialize.java
@@ -9,8 +9,7 @@ public record ChatMessageObjectForSerialize(
     String username,
     String message,
     Date createdAt,
-    Long imageId,
-    ReservationStatus status
+    Long imageId
 ) {
 
 }

--- a/src/main/java/com/hack/stock2u/chat/dto/ChatMessageObjectForSerialize.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/ChatMessageObjectForSerialize.java
@@ -1,0 +1,16 @@
+package com.hack.stock2u.chat.dto;
+
+import com.hack.stock2u.constant.ReservationStatus;
+import java.util.Date;
+import lombok.Builder;
+
+@Builder
+public record ChatMessageObjectForSerialize(
+    String username,
+    String message,
+    Date createdAt,
+    Long imageId,
+    ReservationStatus status
+) {
+
+}

--- a/src/main/java/com/hack/stock2u/chat/dto/ReservationApproveToMessage.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/ReservationApproveToMessage.java
@@ -1,0 +1,10 @@
+package com.hack.stock2u.chat.dto;
+
+import com.hack.stock2u.constant.ReservationStatus;
+import com.hack.stock2u.models.Reservation;
+
+public record ReservationApproveToMessage(
+    ReservationStatus status,
+    Reservation reservation
+) {
+}

--- a/src/main/java/com/hack/stock2u/chat/dto/request/ReservationApproveRequest.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/request/ReservationApproveRequest.java
@@ -1,5 +1,6 @@
 package com.hack.stock2u.chat.dto.request;
 
+import com.hack.stock2u.models.Reservation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
 
@@ -7,5 +8,7 @@ public record ReservationApproveRequest(
     @Schema(required = true, description = "chatmessage에 room_id, reservation에 id")
     @NotNull
     Long roomId
+
+
 ) {
 }

--- a/src/main/java/com/hack/stock2u/chat/dto/request/ReservationApproveRequest.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/request/ReservationApproveRequest.java
@@ -4,10 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
 
 public record ReservationApproveRequest(
-
-    @Schema(required = true, description = "상품 ID")
-    @NotNull
-    Long productId,
     @Schema(required = true, description = "chatmessage에 room_id, reservation에 id")
     @NotNull
     Long roomId

--- a/src/main/java/com/hack/stock2u/chat/dto/response/AlertIdAndMessage.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/AlertIdAndMessage.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 
 @Builder
 public record AlertIdAndMessage(
+    String userName,
+    Long userId,
     Long reservationId,
     String message
 ) {

--- a/src/main/java/com/hack/stock2u/chat/dto/response/AlertIdAndMessage.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/AlertIdAndMessage.java
@@ -1,0 +1,10 @@
+package com.hack.stock2u.chat.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AlertIdAndMessage(
+    Long reservationId,
+    String message
+) {
+}

--- a/src/main/java/com/hack/stock2u/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/ChatMessageResponse.java
@@ -13,7 +13,7 @@ public record ChatMessageResponse(
     String message,
     Date createdAt
 
-//    String image
+
 ) {
   public static ChatMessageResponse create(
       ChatMessage chatMessage) {

--- a/src/main/java/com/hack/stock2u/chat/dto/response/PurchaserSellerReservationsResponse.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/PurchaserSellerReservationsResponse.java
@@ -1,7 +1,11 @@
 package com.hack.stock2u.chat.dto.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record PurchaserSellerReservationsResponse(
     ChatMessageResponse latestChat,
-    SimpleReservation reservationSummary
+    SimpleReservation reservationSummary,
+    @Schema(description = "안 읽은 채팅 수")
+    long count
 ) {}

--- a/src/main/java/com/hack/stock2u/chat/dto/response/ReservationMessageResponse.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/ReservationMessageResponse.java
@@ -12,9 +12,7 @@ import lombok.Builder;
 
 @Builder
 public record ReservationMessageResponse(
-    @Schema(required = true, description = "chatmessage에 id")
-    @NotNull
-    Long roomId,
+
     @Schema(required = true, description = "구매자 이름")
     String purchaserName,
     @Schema(required = true, description = "자동 발송 메세지 내용")
@@ -24,14 +22,15 @@ public record ReservationMessageResponse(
     @NotNull
     Date createdAt,
     @Schema(description = "예약 상태(예약 한 건만 받기 체크 && 예약 진행 중일 시 표기 됨)", nullable = true)
-    ReservationStatus status
+    ReservationStatus status,
+    @Schema(description = "프로필 사진")
+    Long imageId
 ) {
   public static ReservationMessageResponse makingReservationMessage(
       Reservation reservation,
-      Product product, User purchaser,
+       User purchaser,
       ChatMessage chatMessage) {
     return ReservationMessageResponse.builder()
-        .roomId(reservation.getId())
         .message(chatMessage.getMessage())
         .purchaserName(purchaser.getName())
         .createdAt(new Date())

--- a/src/main/java/com/hack/stock2u/chat/service/ChatMessageService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ChatMessageService.java
@@ -106,7 +106,6 @@ public class ChatMessageService {
         .message(message.getMessage())
         .createdAt(message.getCreatedAt())
         .imageId(purchaser.getAvatarId())
-        .status(reservation.getStatus())
         .build());
     String destination = "/topic/chat/room/" + reservation.getId();
 
@@ -142,7 +141,6 @@ public class ChatMessageService {
         .message(message.getMessage())
         .createdAt(message.getCreatedAt())
         .imageId(seller.getAvatarId())
-        .status(approveToMessage.status())
         .build());
     String destination = "/topic/chat/room/" + roomId;
 

--- a/src/main/java/com/hack/stock2u/chat/service/ChatMessageService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ChatMessageService.java
@@ -18,6 +18,7 @@ import com.hack.stock2u.models.Reservation;
 import com.hack.stock2u.models.User;
 import com.hack.stock2u.product.repository.JpaProductRepository;
 import com.hack.stock2u.user.repository.JpaUserRepository;
+import com.hack.stock2u.utils.JsonSerializer;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -32,7 +33,7 @@ public class ChatMessageService {
   private final SimpMessagingTemplate messagingTemplate;
   private final JpaProductRepository productRepository;
   private final SessionManager sessionManager;
-  private final ObjectMapper objectMapper;
+  private final JsonSerializer jsonSerializer;
   // 메시지 저장
 
   public void saveAndSendMessage(SendChatMessage request, Long roomId) {
@@ -56,12 +57,8 @@ public class ChatMessageService {
         .reservationId(roomId)
         .build();
 
-    try {
-      String idAndMessageByJson = objectMapper.writeValueAsString(idAndMessage);
-      messagingTemplate.convertAndSend("/topic/chat/alert/" + opUserId, idAndMessageByJson);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+    Object idAndMessageByJson = jsonSerializer.serialize(idAndMessage);
+    messagingTemplate.convertAndSend("/topic/chat/alert/" + opUserId, idAndMessageByJson);
 
   }
 

--- a/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
@@ -3,6 +3,7 @@ package com.hack.stock2u.chat.service;
 
 import com.hack.stock2u.authentication.dto.SessionUser;
 import com.hack.stock2u.authentication.service.SessionManager;
+import com.hack.stock2u.chat.dto.ReservationApproveToMessage;
 import com.hack.stock2u.chat.dto.ReservationProductPurchaser;
 import com.hack.stock2u.chat.dto.request.ChangeStatusRequest;
 import com.hack.stock2u.chat.dto.request.ReportRequest;
@@ -99,12 +100,12 @@ public class ReservationService {
     reservationRepository.deleteById(id);
   }
 
-  public ReservationStatus approve(ReservationApproveRequest request) {
+  public ReservationApproveToMessage approve(ReservationApproveRequest request) {
     Reservation reservation = reservationRepository.findById(request.roomId())
         .orElseThrow(GlobalException.NOT_FOUND::create);
     reservation.changeStatus(ReservationStatus.PROGRESS);
     reservationRepository.save(reservation);
-    return ReservationStatus.PROGRESS;
+    return new ReservationApproveToMessage(reservation.getStatus(), reservation);
   }
 
   public Short report(ReportRequest request) {

--- a/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ReservationService.java
@@ -27,18 +27,23 @@ import com.hack.stock2u.models.Reservation;
 import com.hack.stock2u.models.User;
 import com.hack.stock2u.product.repository.JpaProductRepository;
 import com.hack.stock2u.user.repository.JpaUserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomStringUtils;
+import net.bytebuddy.asm.Advice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
+
 
 @Slf4j
 @Service
@@ -54,29 +59,32 @@ public class ReservationService {
   private final SessionManager sessionManager;
   private final JpaReportRepository reportRepository;
   private final ReservationMessageHandler reservationMessageHandler;
-
+  private final MongoTemplate mongoTemplate;
   /**
    * 예약 엔티티를 생성합니다.
    */
+
   public ReservationProductPurchaser create(Long productId) {
+
     User purchaser = sessionManager.getSessionUserByRdb();
     Product product = productRepository.findById(productId)
         .orElseThrow(GlobalException.NOT_FOUND::create);
-
+    Date currentDate = new Date();
+    if (product.getExpiredAt().after(currentDate)) {
+      return null;
+    }
     // 잔여재고 남은 갯수가 0개면 예약되지 않음
     if (product.getProductCount() == 0) {
       throw ReservationException.NOT_ENOUGH_COUNT.create();
     }
 
-    String roomId = RandomStringUtils.randomAlphabetic(8);
-    Reservation reservation = reservationRepository.save(
-        Reservation.builder()
-            .purchaser(purchaser)
-            .product(product)
-            .chatId(roomId)
-            .seller(product.getSeller())
-            .build()
-    );
+    Reservation reservation = Reservation.builder()
+        .purchaser(purchaser)
+        .product(product)
+        .seller(product.getSeller())
+        .build();
+    reservation.setCreateAt();
+    reservationRepository.save(reservation);
 
     reservationMessageHandler.publishReservationRequest(
         product.getTitle(),
@@ -88,10 +96,7 @@ public class ReservationService {
   }
 
   public void cancel(Long id) {
-    Reservation r = reservationRepository.findById(id)
-        .orElseThrow(GlobalException.NOT_FOUND::create);
-    r.setDisabledAt(new Date());
-    reservationRepository.save(r);
+    reservationRepository.deleteById(id);
   }
 
   public ReservationStatus approve(ReservationApproveRequest request) {
@@ -145,6 +150,7 @@ public class ReservationService {
     SessionUser u = getSessionUser();
     String role = getUserRole(u);
     Long id = getUserId(u);
+    String userName = u.username();
 
     List<Reservation> reservations = getSellerAndPurchaser(id, role, pageable);
     Stream<Reservation> filteredReservations = reservations.stream();
@@ -157,8 +163,8 @@ public class ReservationService {
     }
 
     List<PurchaserSellerReservationsResponse> responses = filteredReservations
-        .map(Reservation::getId)
-        .map(this::createLatestMessageAndThumbnailAndSimpleReservation)
+        .map(reservation -> createLatestMessageAndThumbnailAndSimpleReservation(
+            reservation.getId(), userName))
         .toList();
 
     return new PageImpl<>(responses);
@@ -190,10 +196,11 @@ public class ReservationService {
   public ReservationStatus changeStatus(ChangeStatusRequest request) {
     //예약 취소, 예약 완료 로직 다르게 짜야함
     Reservation reservation = getReservationId(request.reservationId());
-    if (request.status().equals("예약 취소됌")) {
-      reservation.setDisabledAt(new Date());
+    //setremoveAt을 예약취소
+    if (request.status().equals(ReservationStatus.CANCEL.getName())) {
+      reservation.setRemoveAt(new Date());
     } else {
-      reservation.setDisabledAt(null);
+      reservation.setRemoveAt(null);
     }
     reservation.changeStatus(ReservationStatus.valueOf(request.status()));
 
@@ -223,26 +230,36 @@ public class ReservationService {
 
 
   private PurchaserSellerReservationsResponse
-      createLatestMessageAndThumbnailAndSimpleReservation(Long id) {
+      createLatestMessageAndThumbnailAndSimpleReservation(Long id, String userName) {
 
     ChatMessageResponse messageResponse = latestMessage(id);
 
     Reservation reservation = getReservationId(id);
 
     SimpleThumbnailImage simpleThumbnailImage = getThumbnailImage(reservation);
-
+    long count = getCountOfMessage(userName, id);
     SimpleReservation simpleReservation = SimpleReservation.create(
         reservation, simpleThumbnailImage);
 
-    return new PurchaserSellerReservationsResponse(messageResponse, simpleReservation);
+    return new PurchaserSellerReservationsResponse(messageResponse, simpleReservation, count);
   }
-  //check는 boolean으로 예측되니 이름을 바꾸자
+
+  private long getCountOfMessage(String userName, Long roomId) {
+
+    Query query = new Query(Criteria.where("roomId").is(roomId)
+        .and("read").is(false)
+        .and("userName").ne(userName));
+
+    return mongoTemplate.count(query, ChatMessage.class);
+  }
+
 
   private List<Reservation> getSellerAndPurchaser(Long id, String role, Pageable pageable) {
     return (role.equals(UserRole.SELLER.getName()))
         ? getReservationBySellerId(id, pageable) :
         getReservationByPurchaserId(id, pageable);
   }
+
 
 
   private ChatMessageResponse latestMessage(Long id) {

--- a/src/main/java/com/hack/stock2u/models/ChatMessage.java
+++ b/src/main/java/com/hack/stock2u/models/ChatMessage.java
@@ -41,4 +41,6 @@ public class ChatMessage {
   @Field(name = "timestamp")
   private Date createdAt;
 
+  @Field(name = "message_read")
+  private boolean read;
 }

--- a/src/main/java/com/hack/stock2u/models/Reservation.java
+++ b/src/main/java/com/hack/stock2u/models/Reservation.java
@@ -33,10 +33,6 @@ public class Reservation {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Comment("MongoDB Chat 식별자")
-  @Column(name = "chat_id")
-  private String chatId;
-
   @Comment("잔여 재고")
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_id")
@@ -52,24 +48,25 @@ public class Reservation {
   @JoinColumn(name = "purchaser_id")
   private User purchaser;
 
-  @Column(name = "disabled_at")
-  @Temporal(TemporalType.TIMESTAMP)
-  private Date disabledAt;
-
   @Enumerated(EnumType.STRING)
   private ReservationStatus status;
 
   @Embedded
   private BasicDateColumn basicDate;
 
-  public void setDisabledAt(Date date) {
-    this.disabledAt = date;
+  public void setRemoveAt(Date date) {
+    this.basicDate.setRemovedAt(date);
   }
 
+  public void setCreateAt() {
+    this.basicDate.setCreatedAt(new Date());
+  }
+
+
+
   @Builder
-  public Reservation(String chatId, Product product,
+  public Reservation(Product product,
                       User seller, User purchaser) {
-    this.chatId = chatId;
     this.product = product;
     this.seller = seller;
     this.purchaser = purchaser;

--- a/src/main/java/com/hack/stock2u/utils/JsonSerializer.java
+++ b/src/main/java/com/hack/stock2u/utils/JsonSerializer.java
@@ -1,0 +1,26 @@
+package com.hack.stock2u.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hack.stock2u.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JsonSerializer {
+  private final ObjectMapper objectMapper;
+
+  public Object serialize(Object o) {
+    try {
+      return objectMapper.writeValueAsString(o);
+    } catch (JsonProcessingException e) {
+      log.error(e.toString());
+      e.printStackTrace();
+      throw GlobalException.SERVER_ERROR.create();
+    }
+  }
+
+}


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-0](https://geezers-io.atlassian.net/browse/SU-141)

## What & Why
![image](https://github.com/geezers-io/Stock2U-api/assets/82084599/9c2ffb2e-2aa4-4e64-a443-c8fa1ddc003d)
기존 메세지들을 상대방에게 보낼때 직렬화를 수행하였습니다.
![image](https://github.com/geezers-io/Stock2U-api/assets/82084599/e68a575b-bad5-4aca-b4c0-64ed8ae0ca80)
알림으로 보내는정보와 카운트 정보를 합쳐서 한 경로로 보냈습니다.
## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
