### PR TITLE
feat: 채팅 내역 불러오기 API 작성

### DIFF
--- a/src/main/java/com/hack/stock2u/chat/api/ChatHttpApi.java
+++ b/src/main/java/com/hack/stock2u/chat/api/ChatHttpApi.java
@@ -1,0 +1,33 @@
+package com.hack.stock2u.chat.api;
+
+import com.hack.stock2u.chat.dto.response.ChatHistories;
+import com.hack.stock2u.chat.service.ChatHistoryLoader;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/reservation/chats/history")
+public class ChatHttpApi {
+
+  private final ChatHistoryLoader historyLoader;
+
+  @Operation(summary = "채팅 내역 불러오기 API", description = "커서 기반으로 불러옵니다")
+  @GetMapping
+  public ResponseEntity<ChatHistories> getChatHistoryApi(
+      @Parameter(description = "예약(채팅) ID", required = true)
+      @RequestParam("reservationId") Long reservationId,
+      @Parameter(description = "예약(채팅) ID")
+      @RequestParam(value = "cursor", required = false) Long cursor
+  ) {
+    ChatHistories histories = historyLoader.getHistories(reservationId, cursor);
+    return ResponseEntity.ok(histories);
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/chat/dto/response/ChatHistories.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/response/ChatHistories.java
@@ -1,0 +1,9 @@
+package com.hack.stock2u.chat.dto.response;
+
+import com.hack.stock2u.models.ChatMessage;
+import java.util.Date;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ChatHistories(List<ChatMessage> histories, Long cursor, boolean last) {}

--- a/src/main/java/com/hack/stock2u/chat/repository/MessageChatMongoRepository.java
+++ b/src/main/java/com/hack/stock2u/chat/repository/MessageChatMongoRepository.java
@@ -2,6 +2,7 @@ package com.hack.stock2u.chat.repository;
 
 import com.hack.stock2u.models.ChatMessage;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,5 +19,8 @@ public interface MessageChatMongoRepository extends MongoRepository<ChatMessage,
   long countByRoomIdAndReadIsFalseAndUserNameNot(Long roomId, String userName);
 
   Optional<ChatMessage> findTopByRoomIdOrderByCreatedAtDesc(Long id);
+
+  @Query(value = "{ _id: { $lt:  ?1 }, room_id: { $eq: ?0 } }")
+  List<ChatMessage> findChatHistory(Long roomId, Long cursor, Pageable pageable);
 
 }

--- a/src/main/java/com/hack/stock2u/chat/service/ChatHistoryLoader.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ChatHistoryLoader.java
@@ -1,0 +1,64 @@
+package com.hack.stock2u.chat.service;
+
+import com.hack.stock2u.chat.dto.response.ChatHistories;
+import com.hack.stock2u.chat.repository.MessageChatMongoRepository;
+import com.hack.stock2u.models.ChatMessage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatHistoryLoader {
+  private final MessageChatMongoRepository chatMongoRepository;
+  private final PageRequest pageable = PageRequest
+      .of(0, 30)
+      .withSort(Sort.Direction.DESC, "timestamp");
+
+  public ChatHistories getHistories(Long reservationId, Long cursor) {
+    Optional<ChatMessage> firstMessage =
+        chatMongoRepository.findTopByRoomIdOrderByCreatedAtDesc(reservationId);
+
+    if (firstMessage.isEmpty()) {
+      return new ChatHistories(new ArrayList<>(), null, true);
+    }
+
+    cursor = Objects.requireNonNullElse(cursor, firstMessage.get().getId() + 1);
+
+    List<ChatMessage> histories = chatMongoRepository.findChatHistory(
+        reservationId,
+        cursor,
+        pageable
+    );
+
+    Collections.reverse(histories);
+
+    ChatHistories.ChatHistoriesBuilder historiesBuilder =
+        ChatHistories.builder().histories(histories);
+
+    // 조회된 내역이 있다면
+    if (histories.size() > 0) {
+      ChatMessage chatMessage = histories.get(0);
+      return historiesBuilder
+          .cursor(chatMessage.getId())
+          .last(false)
+          .build();
+    }
+
+    // 조회된 내역이 없다면
+    return historiesBuilder
+        .cursor(null)
+        .last(true)
+        .build();
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/chat/service/ChatMessageService.java
+++ b/src/main/java/com/hack/stock2u/chat/service/ChatMessageService.java
@@ -10,6 +10,7 @@ import com.hack.stock2u.constant.AutoMessageTemplate;
 import com.hack.stock2u.constant.ChatAlertType;
 import com.hack.stock2u.constant.ChatMessageType;
 import com.hack.stock2u.global.exception.GlobalException;
+import com.hack.stock2u.global.service.SequenceGeneratorService;
 import com.hack.stock2u.models.ChatMessage;
 import com.hack.stock2u.models.Reservation;
 import com.hack.stock2u.models.User;
@@ -27,6 +28,7 @@ public class ChatMessageService {
   private final MessageChatMongoRepository messageRepository;
   private final SessionManager sessionManager;
   private final MessageHandler messageHandler;
+  private final SequenceGeneratorService sequenceGeneratorService;
   private final ChatPageMessageHandler chatPageMessageHandler;
   private final ChatAnalyzer chatAnalyzer = new ChatAnalyzer();
   // 메시지 저장
@@ -56,6 +58,7 @@ public class ChatMessageService {
       List<Long> imageIds, ChatMessageType type) {
 
     return messageRepository.save(ChatMessage.builder()
+        .id(sequenceGeneratorService.generateSequence(ChatMessage.SEQUENCE_NAME))
         .type(type)
         .roomId(reservation.getId())
         .userName(user.getName())

--- a/src/main/java/com/hack/stock2u/chat/service/MongoChatListener.java
+++ b/src/main/java/com/hack/stock2u/chat/service/MongoChatListener.java
@@ -1,0 +1,22 @@
+package com.hack.stock2u.chat.service;
+
+import com.hack.stock2u.global.service.SequenceGeneratorService;
+import com.hack.stock2u.models.ChatMessage;
+import com.hack.stock2u.models.embed.MongoAutoIncrementSequence;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class MongoChatListener extends AbstractMongoEventListener<MongoAutoIncrementSequence> {
+  private final SequenceGeneratorService generatorService;
+
+  @Override
+  public void onBeforeConvert(BeforeConvertEvent<MongoAutoIncrementSequence> event) {
+    long count = generatorService.generateSequence(ChatMessage.SEQUENCE_NAME);
+    event.getSource().setSeq(count);
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/global/service/SequenceGeneratorService.java
+++ b/src/main/java/com/hack/stock2u/global/service/SequenceGeneratorService.java
@@ -1,0 +1,30 @@
+package com.hack.stock2u.global.service;
+
+import static org.springframework.data.mongodb.core.query.Criteria.*;
+
+import com.hack.stock2u.models.embed.MongoAutoIncrementSequence;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SequenceGeneratorService {
+  private final MongoOperations operations;
+
+  public long generateSequence(String seqName) {
+    MongoAutoIncrementSequence counter = operations.findAndModify(
+        Query.query(where("_id").is(seqName)),
+        new Update().inc("seq", 1),
+        FindAndModifyOptions.options().returnNew(true).upsert(true),
+        MongoAutoIncrementSequence.class
+    );
+
+    return Objects.nonNull(counter) ? counter.getSeq() + 1 : 1;
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/models/ChatMessage.java
+++ b/src/main/java/com/hack/stock2u/models/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.hack.stock2u.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hack.stock2u.constant.ChatMessageType;
 import java.util.Date;
 import java.util.List;
@@ -8,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldType;
@@ -19,11 +21,16 @@ import org.springframework.data.mongodb.core.mapping.FieldType;
 @Builder
 public class ChatMessage {
 
+  @Transient
+  public static final String SEQUENCE_NAME = "chat_message_sequence";
+
   @Id
-  @Field(value = "_id", targetType = FieldType.OBJECT_ID)
-  private String id;
+  @Field(value = "_id", targetType = FieldType.INT64)
+  @JsonIgnore
+  private Long id;
 
   @Field(name = "room_id")
+  @JsonIgnore
   private Long roomId;
 
   @Field(name = "user_name")

--- a/src/main/java/com/hack/stock2u/models/embed/MongoAutoIncrementSequence.java
+++ b/src/main/java/com/hack/stock2u/models/embed/MongoAutoIncrementSequence.java
@@ -1,0 +1,15 @@
+package com.hack.stock2u.models.embed;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Setter
+@Document(collection = "auto_sequence")
+public class MongoAutoIncrementSequence {
+  @Id
+  private String id;
+  private Long seq;
+}


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-91](https://geezers-io.atlassian.net/browse/SU-91)

## What & Why

채팅 내역 불러오기 API 를 작업하였습니다.
커서 기반으로 동작합니다.
몽고디비에서 자동으로 1씩 늘어나는 아이디 컬럼을 위한 로직을 작성해보았습니다.
이 후 몽고디비 이슈가 다시 발생한다면 MySQL 테이블로 교체작업을 고려해봐야겠습니다.


## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
