### PR TITLE
feat: 채팅 서비스 리팩터링 및 프로필 이미지 로직 추가

### DIFF
--- a/src/main/java/com/hack/stock2u/chat/dto/MessageCreation.java
+++ b/src/main/java/com/hack/stock2u/chat/dto/MessageCreation.java
@@ -1,0 +1,13 @@
+package com.hack.stock2u.chat.dto;
+
+import com.hack.stock2u.models.User;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record MessageCreation(
+    User user,
+    String profileImageUrl,
+    String message,
+    List<Long> imageIds
+) {}

--- a/src/main/java/com/hack/stock2u/file/service/ImageProvider.java
+++ b/src/main/java/com/hack/stock2u/file/service/ImageProvider.java
@@ -1,0 +1,44 @@
+package com.hack.stock2u.file.service;
+
+import com.hack.stock2u.file.repository.JpaAttachRepository;
+import com.hack.stock2u.global.exception.GlobalException;
+import com.hack.stock2u.models.Attach;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ImageProvider {
+  private final JpaAttachRepository attachRepository;
+
+  public List<String> getImageUrls(List<Long> imageIds) {
+    if (imageIds == null) {
+      return null;
+    }
+
+    return attachRepository.findAllById(imageIds)
+        .stream()
+        .map(Attach::getUploadPath)
+        .toList();
+  }
+
+  public Attach findAttachOrThrow(Long id) {
+    if (id == null) {
+      return null;
+    }
+
+    return attachRepository.findById(id).orElseThrow(GlobalException.NOT_FOUND::create);
+  }
+
+  public String getImageOrElseThrow(Long id) {
+    if (id == null) {
+      return null;
+    }
+
+    return attachRepository.findById(id)
+        .orElseThrow(GlobalException.NOT_FOUND::create)
+        .getUploadPath();
+  }
+
+}

--- a/src/main/java/com/hack/stock2u/models/ChatMessage.java
+++ b/src/main/java/com/hack/stock2u/models/ChatMessage.java
@@ -39,6 +39,9 @@ public class ChatMessage {
   @Field(name = "type")
   private ChatMessageType type;
 
+  @Field(name = "profile_image_url")
+  private String profileImageUrl;
+
   @Field(name = "message")
   private String message;
 


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
* 채팅 이미지를 가져오기 위한 DB 통신 요청 최대 5회 -> 1회 단축
* 채팅 서비스의 파일 관련 로직 결합을 이미지 도메인으로 분리
* 일부 메서드를 더 의미있게 사용할 수 있도록 개선

